### PR TITLE
V0.1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "densemap"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["GossiperLoturot"]
 edition = "2021"
 description = "A collection data structure that is permanently accessible by unique keys and fast iterable."

--- a/src/densemap.rs
+++ b/src/densemap.rs
@@ -25,6 +25,40 @@ pub struct Key {
     idx: u32,
 }
 
+impl Key {
+    /// Returns the key generation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use densemap::DenseMap;
+    ///
+    /// let mut densemap = DenseMap::new();
+    /// let key = densemap.insert(11);
+    /// assert_eq!(key.generation(), 0);
+    /// ```
+    #[inline]
+    pub fn generation(&self) -> u32 {
+        self.generation
+    }
+
+    /// Returns the key index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use densemap::DenseMap;
+    ///
+    /// let mut densemap = DenseMap::new();
+    /// let key = densemap.insert(11);
+    /// assert_eq!(key.idx(), 0);
+    /// ```
+    #[inline]
+    pub fn idx(&self) -> u32 {
+        self.idx
+    }
+}
+
 /// An index of sparse layer and mode at the position.
 ///
 /// if `generation` is an even number, the key is in occupied mode, otherwise it is

--- a/src/densemap.rs
+++ b/src/densemap.rs
@@ -673,7 +673,7 @@ impl<T> DenseMap<T> {
             };
             self.next = entry.idx_or_next;
             entry.generation += 1;
-            entry.idx_or_next = self.values.len() as u32;
+            entry.idx_or_next = self.keys.len() as u32;
             self.keys.push(key);
             self.values.push(f(key));
             key
@@ -683,7 +683,7 @@ impl<T> DenseMap<T> {
             }
             let entry = SparseIdx {
                 generation: 0,
-                idx_or_next: self.values.len() as u32,
+                idx_or_next: self.keys.len() as u32,
             };
             let key = Key {
                 generation: 0,
@@ -736,7 +736,7 @@ impl<T> DenseMap<T> {
                 self.next = key.idx;
                 let key = self.keys.swap_remove(idx as usize);
                 let value = self.values.swap_remove(idx as usize);
-                if idx < self.values.len() as u32 {
+                if idx < self.keys.len() as u32 {
                     self.sparse_idx[self.keys[idx as usize].idx as usize].idx_or_next = idx;
                 }
                 return Some((key, value));
@@ -780,9 +780,9 @@ impl<T: fmt::Debug> fmt::Debug for DenseMap<T> {
     }
 }
 
-impl Default for DenseMap<()> {
+impl<T> Default for DenseMap<T> {
     #[inline]
-    fn default() -> DenseMap<()> {
+    fn default() -> DenseMap<T> {
         DenseMap::new()
     }
 }
@@ -900,12 +900,6 @@ impl<'a, T> Iterator for Drain<'a, T> {
         let value = self.inner_values.next()?;
         Some((key, value))
     }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.inner_keys.len();
-        (len, Some(len))
-    }
 }
 
 impl<T> ExactSizeIterator for Drain<'_, T> {
@@ -961,12 +955,6 @@ impl<'a> Iterator for Keys<'a> {
         let key = self.inner.next()?;
         Some(key)
     }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.inner.len();
-        (len, Some(len))
-    }
 }
 
 impl ExactSizeIterator for Keys<'_> {
@@ -1012,12 +1000,6 @@ impl Iterator for IntoKeys {
     fn next(&mut self) -> Option<Key> {
         let key = self.inner.next()?;
         Some(key)
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.inner.len();
-        (len, Some(len))
     }
 }
 
@@ -1074,12 +1056,6 @@ impl<'a, T> Iterator for Values<'a, T> {
         let value = self.inner.next()?;
         Some(value)
     }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.inner.len();
-        (len, Some(len))
-    }
 }
 
 impl<T> ExactSizeIterator for Values<'_, T> {
@@ -1126,12 +1102,6 @@ impl<'a, T> Iterator for ValuesMut<'a, T> {
         let value = self.inner.next()?;
         Some(value)
     }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.inner.len();
-        (len, Some(len))
-    }
 }
 
 impl<T> ExactSizeIterator for ValuesMut<'_, T> {
@@ -1177,12 +1147,6 @@ impl<T> Iterator for IntoValues<T> {
     fn next(&mut self) -> Option<T> {
         let value = self.inner.next()?;
         Some(value)
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.inner.len();
-        (len, Some(len))
     }
 }
 
@@ -1242,12 +1206,6 @@ impl<'a, T> Iterator for Iter<'a, T> {
         let value = self.inner_values.next()?;
         Some((key, value))
     }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.inner_keys.len();
-        (len, Some(len))
-    }
 }
 
 impl<T> ExactSizeIterator for Iter<'_, T> {
@@ -1298,12 +1256,6 @@ impl<'a, T> Iterator for IterMut<'a, T> {
         let value = self.inner_values.next()?;
         Some((key, value))
     }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.inner_keys.len();
-        (len, Some(len))
-    }
 }
 
 impl<T> ExactSizeIterator for IterMut<'_, T> {
@@ -1353,12 +1305,6 @@ impl<T> Iterator for IntoIter<T> {
         let key = self.inner_keys.next()?;
         let value = self.inner_values.next()?;
         Some((key, value))
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.inner_keys.len();
-        (len, Some(len))
     }
 }
 

--- a/src/densemap.rs
+++ b/src/densemap.rs
@@ -271,6 +271,22 @@ impl<T> DenseMap<T> {
         }
     }
 
+    /// Extracts a slice containing the entire keys.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use densemap::DenseMap;
+    ///
+    /// let mut densemap = DenseMap::new();
+    /// densemap.insert(1);
+    /// let key = densemap.as_key_slice();
+    /// ```
+    #[inline]
+    pub fn as_key_slice(&self) -> &[Key] {
+        self.keys.as_slice()
+    }
+
     /// An iterator visiting all values in arbitrary order.
     /// The iterator element type is `&'a T`.
     ///
@@ -327,6 +343,38 @@ impl<T> DenseMap<T> {
         IntoValues {
             inner: self.values.into_iter(),
         }
+    }
+
+    /// Extracts a slice containing the entire value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use densemap::DenseMap;
+    ///
+    /// let mut densemap = DenseMap::new();
+    /// densemap.insert(1);
+    /// let key = densemap.as_value_slice();
+    /// ```
+    #[inline]
+    pub fn as_value_slice(&self) -> &[T] {
+        self.values.as_slice()
+    }
+
+    /// Extracts a mutable slice of the entire value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use densemap::DenseMap;
+    ///
+    /// let mut densemap = DenseMap::new();
+    /// densemap.insert(1);
+    /// let key = densemap.as_value_slice();
+    /// ```
+    #[inline]
+    pub fn as_value_mut_slice(&mut self) -> &mut [T] {
+        self.values.as_mut_slice()
     }
 
     /// An iterator visiting all key-value pairs in arbitrary order.

--- a/tests/densemap.rs
+++ b/tests/densemap.rs
@@ -177,7 +177,10 @@ fn test_iter_mut() {
     let key2 = densemap.insert(0);
     assert_eq!(densemap.len(), 3);
 
-    densemap.values_mut().for_each(|value| *value += 2);
+    let values = densemap.values_mut();
+    assert_eq!(values.len(), 3);
+    values.for_each(|value| *value += 2);
+
     let mut values = densemap.values();
     assert_eq!(values.len(), 3);
     assert_eq!(values.next(), Some(&8));
@@ -185,7 +188,10 @@ fn test_iter_mut() {
     assert_eq!(values.next(), Some(&2));
     assert_eq!(values.next(), None);
 
-    densemap.iter_mut().for_each(|(_, value)| *value += 2);
+    let iter = densemap.iter_mut();
+    assert_eq!(iter.len(), 3);
+    iter.for_each(|(_, value)| *value += 2);
+
     let mut iter = densemap.iter();
     assert_eq!(iter.len(), 3);
     assert_eq!(iter.next(), Some((&key0, &10)));
@@ -222,6 +228,56 @@ fn test_into_iter() {
     assert_eq!(iter.next(), Some((key1, 63)));
     assert_eq!(iter.next(), Some((key2, 3)));
     assert_eq!(iter.next(), None);
+}
+
+#[test]
+fn test_for() {
+    let mut densemap = DenseMap::new();
+    let key0 = densemap.insert(106);
+    let key1 = densemap.insert(17);
+    let key2 = densemap.insert(82);
+
+    for (&key, &value) in &densemap {
+        match key {
+            _ if key == key0 => assert_eq!(value, 106),
+            _ if key == key1 => assert_eq!(value, 17),
+            _ if key == key2 => assert_eq!(value, 82),
+            _ => unreachable!(),
+        }
+    }
+
+    for (_, value) in &mut densemap {
+        *value += 2;
+    }
+
+    for (key, value) in densemap {
+        match key {
+            _ if key == key0 => assert_eq!(value, 108),
+            _ if key == key1 => assert_eq!(value, 19),
+            _ if key == key2 => assert_eq!(value, 84),
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[test]
+fn test_iter_clone() {
+    let mut densemap = DenseMap::new();
+    densemap.insert(106);
+    densemap.insert(17);
+    densemap.insert(82);
+
+    let keys = densemap.keys();
+    let equality = Iterator::zip(keys.clone(), keys).all(|(key0, key1)| key0 == key1);
+    assert!(equality);
+
+    let values = densemap.values();
+    let equality = Iterator::zip(values.clone(), values).all(|(value0, value1)| value0 == value1);
+    assert!(equality);
+
+    let iter = densemap.iter();
+    let equality = Iterator::zip(iter.clone(), iter).all(|(entry0, entry1)| entry0 == entry1);
+    assert!(equality);
 }
 
 #[test]

--- a/tests/densemap.rs
+++ b/tests/densemap.rs
@@ -85,6 +85,24 @@ fn test_len_and_is_empty() {
 }
 
 #[test]
+fn test_slice() {
+    let mut densemap = DenseMap::new();
+    let key0 = densemap.insert(32);
+    let key1 = densemap.insert(64);
+    let key2 = densemap.insert(128);
+    assert_eq!(densemap.len(), 3);
+
+    assert_eq!(densemap.as_key_slice(), &[key0, key1, key2]);
+    assert_eq!(densemap.as_value_slice(), &[32, 64, 128]);
+
+    densemap
+        .as_value_mut_slice()
+        .iter_mut()
+        .for_each(|value| *value -= 1);
+    assert_eq!(densemap.as_value_slice(), &[31, 63, 127]);
+}
+
+#[test]
 fn test_iter() {
     let mut densemap = DenseMap::new();
     let key0 = densemap.insert(17);

--- a/tests/densemap.rs
+++ b/tests/densemap.rs
@@ -1,6 +1,43 @@
 use densemap::DenseMap;
 
 #[test]
+fn test_key() {
+    let mut densemap = DenseMap::new();
+    let key0 = densemap.insert(11);
+    assert_eq!(key0.generation(), 0);
+    assert_eq!(key0.idx(), 0);
+
+    let key1 = densemap.insert(11);
+    assert_eq!(key1.generation(), 0);
+    assert_eq!(key1.idx(), 1);
+
+    densemap.remove(key0);
+    let key2 = densemap.insert(11);
+    assert_eq!(key2.generation(), 2);
+    assert_eq!(key2.idx(), 0);
+}
+
+#[test]
+fn test_pure() {
+    let mut densemap0 = DenseMap::new();
+    let mut densemap1 = DenseMap::new();
+
+    let key00 = densemap0.insert(11);
+    let key10 = densemap1.insert(32);
+    assert_eq!(key00, key10);
+
+    let key01 = densemap0.insert(11);
+    let key11 = densemap1.insert(32);
+    assert_eq!(key01, key11);
+
+    densemap0.remove(key00);
+    densemap1.remove(key10);
+    let key02 = densemap0.insert(11);
+    let key12 = densemap1.insert(32);
+    assert_eq!(key02, key12);
+}
+
+#[test]
 fn test_new() {
     let mut densemap = DenseMap::new();
     assert_eq!(densemap.capacity(), (0, 0));


### PR DESCRIPTION
Changes
- Adds some function to access `Key` field.
- Adds some function to return a slice containing key and value in `DenseMap`.
- Fixes `Default` trait generics at `DenseMap`.